### PR TITLE
Fix file picker interactions across browsers

### DIFF
--- a/main.js
+++ b/main.js
@@ -457,9 +457,19 @@ let globalSpeedFactor = Number(speedSlider.value)/100; // 0.33 par défaut
 function updateCount(){ const n=agents.length; countLbl.textContent = n + (n>1?' invaders':' invader'); }
 speedSlider.addEventListener('input', ()=>{ globalSpeedFactor = Number(speedSlider.value)/100; });
 
-const openPicker = () => { try { fileInput.click(); } catch(e) {} };
-addBtn.addEventListener('click', openPicker, { passive: true });
-addBtn.addEventListener('touchend', openPicker, { passive: true });
+const openPicker = (e) => {
+  if (e) e.preventDefault();
+  try {
+    if (typeof fileInput.showPicker === 'function') {
+      fileInput.showPicker();
+    } else {
+      fileInput.click();
+    }
+  } catch (err) {}
+};
+['click','pointerup','touchend'].forEach(evt=>
+  addBtn.addEventListener(evt, openPicker, { passive:false })
+);
 
 fileInput.addEventListener('change', async e=>{
   if(!e.target.files || e.target.files.length===0) return;

--- a/style.css
+++ b/style.css
@@ -47,7 +47,7 @@ html, body { margin: 0; height: 100%; background: #000; color: var(--text);
   position: fixed;
   left: -10000px; top: -10000px;
   width: 1px; height: 1px;
-  opacity: 0; pointer-events: none;
+  opacity: 0;
 }
 
 @media (max-width: 430px) {


### PR DESCRIPTION
## Summary
- ensure Add Invader button opens file picker without passive listeners
- support `showPicker` when available and fall back to `click`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e5ffdbc188322a353b4c40d8d8864