### PR TITLE
Add single-file Invader-inspired mobile web game (Invader Hunt: Paris)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,161 +1,64 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />
-  <title>Pocket Isometric Safari</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>Invader Hunt Paris</title>
   <style>
-    :root { --bg:#0f172a; --ui:#111827cc; --text:#e5e7eb; --accent:#22c55e; }
-    html,body { margin:0; height:100%; background:linear-gradient(#0b1324,#111827); color:var(--text); font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", Inter, sans-serif; overflow:hidden; touch-action:none; }
-    #wrap { position:fixed; inset:0; display:flex; flex-direction:column; }
-    #hud { display:flex; justify-content:space-between; align-items:center; padding: max(env(safe-area-inset-top),10px) 12px 10px; background:var(--ui); backdrop-filter: blur(10px); font-weight:600; z-index:3; }
-    #hud .pill { background:#1f2937aa; border:1px solid #374151; padding:6px 10px; border-radius:999px; font-size:13px; }
-    #game { width:100%; height:100%; display:block; image-rendering: auto; }
-    #controls { position:fixed; left:0; right:0; bottom:0; padding:8px 12px max(env(safe-area-inset-bottom),12px); display:flex; justify-content:space-between; gap:10px; z-index:4; }
-    .btn { flex:1; max-width:110px; padding:12px 10px; border-radius:14px; border:1px solid #4b5563; background:#111827dd; color:#f3f4f6; font-weight:700; text-align:center; user-select:none; }
-    .btn:active { transform:scale(.98); background:#1f2937; }
-    #tip { position:fixed; top:58px; left:50%; transform:translateX(-50%); background:#0b1220d9; border:1px solid #334155; border-radius:10px; padding:8px 10px; font-size:12px; z-index:5; }
+    html, body { margin:0; height:100%; background:#070b14; overflow:hidden; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; }
+    #game { width:100vw; height:100vh; display:block; touch-action:none; }
+    .hud { position:fixed; left:0; right:0; top:0; padding:calc(env(safe-area-inset-top,0px) + 10px) 12px 8px; display:flex; justify-content:space-between; pointer-events:none; color:#f5f7ff; text-shadow:0 2px 5px rgba(0,0,0,.8); font-weight:700; }
+    .capture { position:fixed; bottom:calc(env(safe-area-inset-bottom,0px) + 18px); left:50%; transform:translateX(-50%); width:88px; height:88px; border-radius:999px; border:5px solid #fff; box-shadow:0 0 0 8px rgba(255,255,255,.2); background:rgba(255,255,255,.08); }
+    .capture:active{ transform:translateX(-50%) scale(.96); }
+    .overlay { position:fixed; inset:0; display:flex; align-items:center; justify-content:center; color:#fff; text-align:center; background:linear-gradient(#0008,#000c); }
+    .panel{ background:#111a2be6; border:1px solid #62a4ff66; padding:22px; border-radius:14px; max-width:90vw; }
+    button{ padding:12px 20px; font-weight:700; border:none; border-radius:10px; background:#2f9cff; color:#fff; }
   </style>
 </head>
 <body>
-<div id="wrap">
-  <div id="hud">
-    <div class="pill">Zone: Verdant Rise</div>
-    <div class="pill" id="creatureCount">Creatures: 0</div>
-    <div class="pill" id="fps">FPS: --</div>
-  </div>
-  <canvas id="game"></canvas>
-</div>
-<div id="tip">Tap creature to interact • Move: D-pad</div>
-<div id="controls" aria-label="Touch controls">
-  <div class="btn" data-key="ArrowLeft">◀</div>
-  <div class="btn" data-key="ArrowUp">▲</div>
-  <div class="btn" data-key="ArrowDown">▼</div>
-  <div class="btn" data-key="ArrowRight">▶</div>
-  <div class="btn" data-key="Space">ACT</div>
-</div>
+<canvas id="game"></canvas>
+<div class="hud"><div id="score">Score: 0</div><div id="timer">02:00</div></div>
+<button id="capture" class="capture" aria-label="Capture"></button>
+<div id="overlay" class="overlay"><div class="panel"><h1>Invader Hunt: Paris</h1><p>Find and photograph wall mosaics in 2 minutes.<br/>Move: left thumb drag<br/>Look: right thumb drag</p><button id="start">Start Game</button></div></div>
 <script>
-(() => {
-  const canvas = document.getElementById('game');
-  const ctx = canvas.getContext('2d');
-  const countEl = document.getElementById('creatureCount');
-  const fpsEl = document.getElementById('fps');
-  const keys = new Set();
-  const DPR = Math.min(window.devicePixelRatio || 1, 2);
-  let W=0,H=0;
-
-  const tileW = 96, tileH = 48;
-  const mapW = 18, mapH = 18;
-  const heightMap = Array.from({length:mapH},(_,y)=>Array.from({length:mapW},(_,x)=>Math.floor(2+Math.sin(x*0.45)*1.2+Math.cos(y*0.6)*1.4+Math.random()*1.4)));
-
-  const player = {x:7.5,y:7.5,speed:3.1};
-  const creatures = Array.from({length:12}, (_,i)=>(
-    {x:2+Math.random()*13,y:2+Math.random()*13,hue:(i*37)%360,t:Math.random()*10, mood:'calm'}));
-
-  function resize(){
-    W = innerWidth; H = innerHeight;
-    canvas.width = Math.floor(W*DPR); canvas.height = Math.floor(H*DPR);
-    canvas.style.width = W+'px'; canvas.style.height = H+'px';
-    ctx.setTransform(DPR,0,0,DPR,0,0);
-  }
-  addEventListener('resize', resize); resize();
-
-  function iso(x,y,z=0){
-    const sx = (x-y)*tileW*0.5 + W*0.5;
-    const sy = (x+y)*tileH*0.5 - z*20 + H*0.22;
-    return {sx,sy};
-  }
-
-  function tileColor(h){
-    const g = 95 + h*14;
-    return `rgb(${28+h*4},${Math.min(200,g)},${40+h*2})`;
-  }
-
-  function drawTile(x,y,h){
-    const p=iso(x,y,h), pR=iso(x+1,y,h), pB=iso(x,y+1,h), pD=iso(x+1,y+1,h);
-    ctx.beginPath();
-    ctx.moveTo(p.sx,p.sy);ctx.lineTo(pR.sx,pR.sy);ctx.lineTo(pD.sx,pD.sy);ctx.lineTo(pB.sx,pB.sy);ctx.closePath();
-    ctx.fillStyle=tileColor(h);ctx.fill();
-    ctx.strokeStyle='rgba(0,0,0,.13)';ctx.stroke();
-
-    // rich edge shading
-    ctx.beginPath();ctx.moveTo(pB.sx,pB.sy);ctx.lineTo(pD.sx,pD.sy);ctx.lineTo(pD.sx,pD.sy+18);ctx.lineTo(pB.sx,pB.sy+18);ctx.closePath();
-    ctx.fillStyle='rgba(20,40,20,.42)';ctx.fill();
-    ctx.beginPath();ctx.moveTo(pR.sx,pR.sy);ctx.lineTo(pD.sx,pD.sy);ctx.lineTo(pD.sx,pD.sy+18);ctx.lineTo(pR.sx,pR.sy+18);ctx.closePath();
-    ctx.fillStyle='rgba(10,30,10,.25)';ctx.fill();
-
-    if(Math.random()<0.015){ // ambient flowers
-      ctx.fillStyle='rgba(255,180,220,.85)'; ctx.beginPath(); ctx.arc((p.sx+pD.sx)/2, (p.sy+pD.sy)/2, 2.2,0,Math.PI*2); ctx.fill();
+const c = document.getElementById('game'), ctx = c.getContext('2d');
+const scoreEl = document.getElementById('score'), timerEl = document.getElementById('timer');
+const overlay = document.getElementById('overlay'), startBtn = document.getElementById('start'), captureBtn = document.getElementById('capture');
+let w,h, score=0, timeLeft=120, running=false, flash=0;
+const player = {x:0,y:0,z:0, yaw:0, pitch:0};
+const move={x:0,y:0}, look={x:0,y:0};
+const invaders=[];
+function resize(){w=c.width=innerWidth*devicePixelRatio; h=c.height=innerHeight*devicePixelRatio; ctx.setTransform(devicePixelRatio,0,0,devicePixelRatio,0,0);} resize(); addEventListener('resize',resize);
+function seeded(i){ return (Math.sin(i*999.13)*43758.5453)%1; }
+function makeInvader(seed, size){ const s=size; const arr=[]; for(let y=0;y<s;y++){ arr[y]=[]; for(let x=0;x<Math.ceil(s/2);x++){ const on=seeded(seed+x*17+y*29)>0.45; arr[y][x]=on; arr[y][s-1-x]=on; } } return arr; }
+const sizes=[8,10,12,14,18], pts={8:10,10:20,12:30,14:50,18:100};
+for(let i=0;i<70;i++){
+  const street=Math.floor(i/10), side=i%2? -1:1, z=(i%10)*26-120 + street*2;
+  const size=sizes[Math.floor(Math.random()*sizes.length)], pattern=makeInvader(i+3,size);
+  invaders.push({x:side*10.2, y:2+Math.random()*3.8, z, size, pattern, value:pts[size], taken:false, color:`hsl(${Math.random()*360},85%,55%)`});
+}
+function toCam(p){ const dx=p.x-player.x, dy=p.y-player.y, dz=p.z-player.z; const cy=Math.cos(-player.yaw), sy=Math.sin(-player.yaw); const x=dx*cy-dz*sy, z=dx*sy+dz*cy; const cp=Math.cos(-player.pitch), sp=Math.sin(-player.pitch); const y=dy*cp-z*sp; const z2=dy*sp+z*cp; return {x,y,z:z2}; }
+function project(v){ if(v.z<0.2) return null; const f=700; return {x:w/devicePixelRatio/2 + v.x*f/v.z, y:h/devicePixelRatio/2 - v.y*f/v.z, s:f/v.z}; }
+function drawCity(){
+  const grd=ctx.createLinearGradient(0,0,0,h/devicePixelRatio); grd.addColorStop(0,'#27426b'); grd.addColorStop(0.6,'#355c8b'); grd.addColorStop(1,'#2a2f3a'); ctx.fillStyle=grd; ctx.fillRect(0,0,w,h);
+  ctx.fillStyle='#4e4a42'; ctx.fillRect(0,h/devicePixelRatio*0.65,w,h*0.35/devicePixelRatio);
+  for(let n=-12;n<24;n++){
+    const z=n*16; for(const side of [-1,1]){ const base=toCam({x:side*12,y:0,z}); const top=toCam({x:side*12,y:12,z}); const base2=toCam({x:side*12,y:0,z+14}); const top2=toCam({x:side*12,y:12,z+14});
+      const p1=project(base), p2=project(top), p3=project(top2), p4=project(base2); if(!p1||!p2||!p3||!p4) continue;
+      ctx.fillStyle=side<0?'#c8bea6':'#b8ae96'; ctx.beginPath(); ctx.moveTo(p1.x,p1.y); ctx.lineTo(p2.x,p2.y); ctx.lineTo(p3.x,p3.y); ctx.lineTo(p4.x,p4.y); ctx.closePath(); ctx.fill();
     }
   }
-
-  function drawCreature(c){
-    const h = heightMap[Math.floor(c.y)]?.[Math.floor(c.x)] || 2;
-    const p = iso(c.x,c.y,h+0.5);
-    const bob = Math.sin(c.t*2.5)*4;
-    ctx.save(); ctx.translate(p.sx,p.sy-22+bob);
-    ctx.fillStyle=`hsl(${c.hue} 70% 55%)`; ctx.beginPath(); ctx.ellipse(0,0,14,10,0,0,Math.PI*2); ctx.fill();
-    ctx.fillStyle=`hsl(${(c.hue+25)%360} 80% 65%)`; ctx.beginPath(); ctx.arc(-6,-8,6,0,Math.PI*2); ctx.arc(6,-8,6,0,Math.PI*2); ctx.fill();
-    ctx.fillStyle='#111827'; ctx.beginPath(); ctx.arc(-4,-2,1.8,0,Math.PI*2); ctx.arc(4,-2,1.8,0,Math.PI*2); ctx.fill();
-    ctx.restore();
-  }
-
-  function drawPlayer(){
-    const h = heightMap[Math.floor(player.y)]?.[Math.floor(player.x)] || 2;
-    const p = iso(player.x,player.y,h+0.6);
-    ctx.save(); ctx.translate(p.sx,p.sy-26);
-    ctx.fillStyle='#fde68a'; ctx.beginPath(); ctx.arc(0,0,12,0,Math.PI*2); ctx.fill();
-    ctx.fillStyle='#ef4444'; ctx.fillRect(-12,-3,24,6);
-    ctx.fillStyle='#111827'; ctx.beginPath(); ctx.arc(-4,-2,1.8,0,Math.PI*2); ctx.arc(4,-2,1.8,0,Math.PI*2); ctx.fill();
-    ctx.restore();
-  }
-
-  let last=performance.now(), fpsTick=0, frames=0;
-  function loop(now){
-    const dt = Math.min((now-last)/1000,0.033); last=now;
-    const mvx=(keys.has('ArrowRight')?1:0)-(keys.has('ArrowLeft')?1:0);
-    const mvy=(keys.has('ArrowDown')?1:0)-(keys.has('ArrowUp')?1:0);
-    player.x=Math.max(1,Math.min(mapW-2,player.x+mvx*player.speed*dt));
-    player.y=Math.max(1,Math.min(mapH-2,player.y+mvy*player.speed*dt));
-
-    for(const c of creatures){
-      c.t += dt;
-      c.x += Math.sin(c.t + c.hue)*0.18*dt; c.y += Math.cos(c.t*1.3 + c.hue)*0.18*dt;
-      c.x=Math.max(1,Math.min(mapW-2,c.x)); c.y=Math.max(1,Math.min(mapH-2,c.y));
-    }
-
-    ctx.clearRect(0,0,W,H);
-    for(let y=0;y<mapH;y++) for(let x=0;x<mapW;x++) drawTile(x,y,heightMap[y][x]);
-    creatures.sort((a,b)=>(a.x+a.y)-(b.x+b.y));
-    for(const c of creatures) drawCreature(c);
-    drawPlayer();
-
-    frames++; fpsTick+=dt;
-    if(fpsTick>0.5){ fpsEl.textContent='FPS: '+Math.round(frames/fpsTick); fpsTick=0; frames=0; }
-    countEl.textContent='Creatures: '+creatures.length;
-    requestAnimationFrame(loop);
-  }
-  requestAnimationFrame(loop);
-
-  addEventListener('keydown',e=>keys.add(e.code==='Space'?'Space':e.key));
-  addEventListener('keyup',e=>keys.delete(e.code==='Space'?'Space':e.key));
-  document.querySelectorAll('.btn').forEach(btn=>{
-    const k=btn.dataset.key;
-    const on=()=>keys.add(k), off=()=>keys.delete(k);
-    btn.addEventListener('touchstart',e=>{e.preventDefault();on();},{passive:false});
-    btn.addEventListener('touchend',off);
-    btn.addEventListener('mousedown',on); btn.addEventListener('mouseup',off); btn.addEventListener('mouseleave',off);
-  });
-
-  canvas.addEventListener('touchstart', e=>{
-    const t=e.touches[0]; const x=t.clientX,y=t.clientY;
-    for(const c of creatures){
-      const h = heightMap[Math.floor(c.y)]?.[Math.floor(c.x)]||2;
-      const p=iso(c.x,c.y,h+0.5);
-      if(Math.hypot(p.sx-x,(p.sy-22)-y)<24){ c.hue=(c.hue+70)%360; c.mood='excited'; }
-    }
-  }, {passive:true});
-})();
+}
+function drawInvader(inv){ if(inv.taken) return; const cam=toCam(inv); const p=project(cam); if(!p) return; const tile=Math.max(2,p.s*0.09); const size=inv.size*tile; const ox=p.x-size/2, oy=p.y-size/2; ctx.fillStyle='#1d1d24'; ctx.fillRect(ox-4,oy-4,size+8,size+8); ctx.fillStyle=inv.color; for(let y=0;y<inv.size;y++) for(let x=0;x<inv.size;x++) if(inv.pattern[y][x]) ctx.fillRect(ox+x*tile,oy+y*tile,tile-0.3,tile-0.3); inv._screen={x:ox,y:oy,w:size,h:size,centerX:p.x,centerY:p.y,depth:cam.z}; }
+function update(dt){ player.yaw+=look.x*dt*0.002; player.pitch=Math.max(-0.8,Math.min(0.8,player.pitch+look.y*dt*0.002)); const sp=dt*0.013; player.x+=(Math.cos(player.yaw)*move.x+Math.sin(player.yaw)*move.y)*sp; player.z+=(-Math.sin(player.yaw)*move.x+Math.cos(player.yaw)*move.y)*sp; player.x=Math.max(-5,Math.min(5,player.x)); player.z=Math.max(-140,Math.min(145,player.z)); }
+function attemptCapture(){ if(!running) return; let best=null; for(const inv of invaders){ if(inv.taken||!inv._screen) continue; const cx=w/devicePixelRatio/2, cy=h/devicePixelRatio/2; const d=Math.hypot(inv._screen.centerX-cx, inv._screen.centerY-cy); if(d<70 && inv._screen.depth<38 && (!best||d<best.d)) best={inv,d}; } if(best){ best.inv.taken=true; score+=best.inv.value; scoreEl.textContent=`Score: ${score}`; flash=180; }}
+let prev=performance.now();
+function loop(t){ const dt=t-prev; prev=t; if(running){ timeLeft=Math.max(0,timeLeft-dt/1000); if(timeLeft===0){ running=false; overlay.style.display='flex'; overlay.querySelector('.panel').innerHTML=`<h2>Time's up!</h2><p>Final score: <b>${score}</b></p><button id='restart'>Play Again</button>`; document.getElementById('restart').onclick=start; } const m=Math.floor(timeLeft/60), s=Math.floor(timeLeft%60); timerEl.textContent=`${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`; update(dt);} drawCity(); invaders.sort((a,b)=>(b._screen?.depth||0)-(a._screen?.depth||0)); invaders.forEach(drawInvader); ctx.strokeStyle='rgba(255,255,255,.85)'; ctx.lineWidth=2; const cx=w/devicePixelRatio/2, cy=h/devicePixelRatio/2; ctx.beginPath(); ctx.moveTo(cx-14,cy); ctx.lineTo(cx+14,cy); ctx.moveTo(cx,cy-14); ctx.lineTo(cx,cy+14); ctx.stroke(); if(flash>0){ctx.fillStyle=`rgba(255,255,255,${flash/220})`; ctx.fillRect(0,0,w,h); flash-=dt;} requestAnimationFrame(loop);} requestAnimationFrame(loop);
+function start(){ score=0; timeLeft=120; running=true; overlay.style.display='none'; invaders.forEach(v=>v.taken=false); player.x=0; player.y=0; player.z=0; player.yaw=0; player.pitch=0; scoreEl.textContent='Score: 0'; }
+startBtn.onclick=start; captureBtn.onclick=attemptCapture;
+function bindTouch(e, isStart){ const t=[...e.touches]; if(t[0]){ if(t[0].clientX<innerWidth*0.45){move.x=(t[0].clientY-innerHeight*0.8)/30; move.y=(t[0].clientX-innerWidth*0.2)/30;} else {look.x=(t[0].clientX-innerWidth*0.8)/26; look.y=(t[0].clientY-innerHeight*0.4)/26;}} if(t[1]){ const a=t[0],b=t[1]; const L=a.clientX<b.clientX?a:b, R=a.clientX<b.clientX?b:a; move.x=(L.clientY-innerHeight*0.8)/30; move.y=(L.clientX-innerWidth*0.2)/30; look.x=(R.clientX-innerWidth*0.8)/26; look.y=(R.clientY-innerHeight*0.4)/26; } if(!t.length){move.x=move.y=look.x=look.y=0;} e.preventDefault(); }
+addEventListener('touchstart',e=>bindTouch(e,true),{passive:false}); addEventListener('touchmove',e=>bindTouch(e,false),{passive:false}); addEventListener('touchend',e=>bindTouch(e,false),{passive:false});
+let mouseDown=false; addEventListener('mousedown',e=>{mouseDown=true;}); addEventListener('mouseup',()=>{mouseDown=false;move.x=move.y=look.x=look.y=0;}); addEventListener('mousemove',e=>{ if(!mouseDown) return; look.x=e.movementX*0.6; look.y=e.movementY*0.6; move.x=-1; });
 </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a self-contained, folder-free mobile web game that implements the street-mosaic/Invader photo-hunt concept while avoiding external asset folders. 
- Deliver a touch-first, iPhone-safe gameplay prototype that runs fullscreen in a single HTML page and demonstrates the full requested 2-minute capture/score loop.

### Description
- Replaced the page with a single-page app `index.html` containing a fullscreen canvas game loop, HUD, large touch `Capture` button, start/overlay UI, and iPhone safe-area awareness. 
- Implemented procedural 3D-styled street rendering and perspective projection to portray a Paris-like corridor with depth-sorted wall placements for invader mosaics. 
- Added procedural invader generation (symmetrical pixel mosaics), randomized placements, tiered scoring by size (10/20/30/50/100), camera-capture detection, camera flash feedback, and end-of-run overlay with replay. 
- Implemented touchscreen-first dual-thumb movement/look controls and a desktop mouse fallback for local testing, all kept inline so no external assets or folders are required.

### Testing
- Ran `node --check index.html` as an automated syntax-style check and it failed with `Unknown file extension ".html"` because Node does not perform HTML script validation in this mode. 
- No other automated tests were included in the repo for this change; runtime validation is intended to be performed by opening `index.html` in a browser on an iPhone 14 Pro simulator or device.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f700f478e4832282e8a2481b293f84)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces essentially all of `index.html` with a new rendering/input/game-loop implementation; main risk is gameplay bugs, performance regressions, or broken touch interactions across devices.
> 
> **Overview**
> Replaces the prior isometric “creature” demo page with a new single-file fullscreen canvas game, **Invader Hunt: Paris**, including a start/finish overlay, HUD (score + 2‑minute timer), and a large touch-first `Capture` button with safe-area-aware layout.
> 
> Implements a new procedural 3D/perspective street renderer and procedurally-generated symmetric “invader” mosaics placed along walls, plus capture detection (crosshair proximity/depth), tiered scoring by invader size, flash feedback, and restart flow. Input handling is reworked to dual-thumb touch drag for move/look with a mouse fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 404b240c3703328b46c89f102788ffa210e17e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->