### PR TITLE
Fix iPhone touch interactions and revamp UI/UX for Neon Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,269 +1,83 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>Invader Hunt: Paris Neon Ops</title>
+  <title>Invader Hunt: Neon Safari</title>
   <style>
     :root {
-      --bg-0: #04070f;
-      --bg-1: #081225;
-      --hud: #d6ecff;
-      --accent: #36b7ff;
-      --accent-2: #9a64ff;
-      --danger: #ff4b7f;
+      --bg-0: #02040b;
+      --bg-1: #081832;
+      --hud: #e9f4ff;
+      --accent: #4ec3ff;
+      --accent-2: #a568ff;
+      --danger: #ff5b8c;
     }
-    html, body {
-      margin: 0;
-      height: 100%;
-      overflow: hidden;
-      font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      background:
-        radial-gradient(circle at 20% 10%, #153259 0%, transparent 35%),
-        radial-gradient(circle at 80% 20%, #301755 0%, transparent 38%),
-        linear-gradient(180deg, var(--bg-1), var(--bg-0));
-      color: white;
-    }
+    * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+    html, body { margin: 0; height: 100%; overflow: hidden; font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    body { background: radial-gradient(circle at 20% 10%, #173b67 0%, transparent 35%), radial-gradient(circle at 80% 20%, #31195b 0%, transparent 38%), linear-gradient(180deg, var(--bg-1), var(--bg-0)); color: white; }
     #game { width: 100vw; height: 100vh; display: block; touch-action: none; }
-
-    .vignette {
-      position: fixed; inset: 0; pointer-events: none;
-      background: radial-gradient(circle, transparent 45%, rgba(0,0,0,.35) 100%);
-      mix-blend-mode: multiply;
-      z-index: 5;
-    }
-
-    .hud {
-      position: fixed; left: 0; right: 0; top: 0;
-      padding: calc(env(safe-area-inset-top,0px) + 10px) 14px 10px;
-      display: flex; justify-content: space-between; align-items: center;
-      color: var(--hud);
-      text-shadow: 0 2px 8px rgba(0,0,0,.85);
-      pointer-events: none;
-      z-index: 8;
-      font-weight: 700;
-      letter-spacing: .03em;
-    }
-    .hud .left, .hud .right { display: flex; gap: 10px; align-items: center; }
-    .pill {
-      border: 1px solid rgba(127,186,255,.4);
-      background: linear-gradient(180deg, rgba(13,31,56,.8), rgba(7,16,30,.7));
-      box-shadow: 0 8px 20px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.08);
-      padding: 8px 12px;
-      border-radius: 999px;
-      min-width: 92px;
-      text-align: center;
-    }
-
-    .capture {
-      position: fixed;
-      bottom: calc(env(safe-area-inset-bottom,0px) + 18px);
-      left: 50%;
-      transform: translateX(-50%);
-      width: 98px; height: 98px;
-      border-radius: 999px;
-      border: 5px solid #f0f7ff;
-      box-shadow: 0 0 0 10px rgba(224,244,255,.14), 0 0 35px rgba(54,183,255,.35);
-      background: radial-gradient(circle at 30% 30%, rgba(255,255,255,.5), rgba(255,255,255,.08) 45%, rgba(54,183,255,.2));
-      z-index: 9;
-      transition: transform .08s ease, box-shadow .15s ease;
-    }
-    .capture:active { transform: translateX(-50%) scale(.95); box-shadow: 0 0 0 7px rgba(255,255,255,.16), 0 0 45px rgba(54,183,255,.7); }
-
-    .overlay {
-      position: fixed; inset: 0; z-index: 10;
-      display: flex; align-items: center; justify-content: center;
-      color: #fff; text-align: center;
-      background: radial-gradient(circle at 50% 20%, rgba(34,76,144,.25), rgba(3,5,11,.92));
-      backdrop-filter: blur(5px);
-      padding: 20px;
-    }
-    .panel {
-      width: min(720px, 92vw);
-      padding: 28px;
-      border-radius: 20px;
-      border: 1px solid rgba(117,169,255,.45);
-      background: linear-gradient(160deg, rgba(11,23,44,.92), rgba(7,16,32,.93));
-      box-shadow: 0 30px 90px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,255,255,.08);
-    }
-    h1 { margin: 0 0 8px; font-size: clamp(28px, 5vw, 52px); }
-    h2 { margin: 0 0 8px; font-size: clamp(24px, 4vw, 44px); }
-    .subtitle { opacity: .86; margin-bottom: 14px; }
-    .stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin: 16px 0 22px; }
-    .stat { padding: 10px; border-radius: 12px; background: rgba(17,39,71,.55); border: 1px solid rgba(129,183,255,.3); font-size: 13px; }
-    .stat b { display: block; font-size: 16px; margin-top: 4px; }
-
-    button {
-      padding: 14px 24px;
-      font-size: 28px;
-      font-weight: 800;
-      border: 0;
-      border-radius: 12px;
-      color: white;
-      background: linear-gradient(180deg, #4cb8ff, #1f8fff);
-      box-shadow: 0 12px 26px rgba(28,145,255,.35);
-      cursor: pointer;
-      min-width: 230px;
-    }
+    .vignette { position: fixed; inset: 0; pointer-events: none; background: radial-gradient(circle, transparent 35%, rgba(0,0,0,.5)); z-index: 5; }
+    .hud { position: fixed; left: 0; right: 0; top: 0; padding: calc(env(safe-area-inset-top,0px) + 10px) 12px 10px; display: flex; justify-content: space-between; align-items: center; z-index: 8; pointer-events: none; }
+    .hud .left, .hud .right { display: flex; gap: 8px; }
+    .pill { border: 1px solid rgba(122,193,255,.45); color: var(--hud); background: linear-gradient(180deg, rgba(9,26,50,.85), rgba(6,16,31,.78)); box-shadow: 0 8px 18px rgba(0,0,0,.4), inset 0 1px 0 rgba(255,255,255,.1); padding: 8px 10px; border-radius: 999px; min-width: 80px; text-align: center; font-weight: 700; font-size: 13px; text-shadow: 0 2px 10px rgba(0,0,0,.8); }
+    .capture { position: fixed; bottom: calc(env(safe-area-inset-bottom,0px) + 20px); left: 50%; transform: translateX(-50%); width: 88px; height: 88px; border-radius: 999px; border: 4px solid #f4f9ff; background: radial-gradient(circle at 30% 30%, rgba(255,255,255,.8), rgba(255,255,255,.1) 42%, rgba(78,195,255,.2)); box-shadow: 0 0 0 10px rgba(224,244,255,.12), 0 0 30px rgba(54,183,255,.45); z-index: 9; }
+    .capture:active { transform: translateX(-50%) scale(.95); }
+    .controls-help { position: fixed; left: 50%; transform: translateX(-50%); bottom: calc(env(safe-area-inset-bottom,0px) + 118px); z-index: 8; font-size: 12px; color: rgba(229,244,255,.8); text-shadow: 0 2px 8px rgba(0,0,0,.9); pointer-events: none; }
+    .overlay { position: fixed; inset: 0; z-index: 20; display: flex; align-items: center; justify-content: center; text-align: center; background: radial-gradient(circle at 50% 10%, rgba(42,88,160,.24), rgba(2,4,12,.94)); padding: max(16px, env(safe-area-inset-top,0px)) 16px max(16px, env(safe-area-inset-bottom,0px)); }
+    .panel { width: min(760px, 94vw); padding: 22px; border-radius: 22px; border: 1px solid rgba(119,178,255,.5); background: linear-gradient(160deg, rgba(11,24,48,.95), rgba(7,15,30,.95)); box-shadow: 0 30px 90px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.09); }
+    h1 { margin: 0 0 8px; font-size: clamp(28px, 7vw, 56px); }
+    h2 { margin: 0 0 10px; font-size: clamp(24px, 6vw, 46px); }
+    .subtitle { opacity: .9; margin-bottom: 10px; }
+    .stats { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 8px; margin: 14px 0 20px; }
+    .stat { padding: 10px; border-radius: 10px; background: rgba(15,38,72,.56); border: 1px solid rgba(129,183,255,.35); font-size: 12px; }
+    .stat b { display: block; font-size: 15px; margin-top: 4px; }
+    button.primary { padding: 14px 22px; font-size: clamp(20px,5vw,28px); font-weight: 800; border: 0; border-radius: 14px; color: white; background: linear-gradient(180deg, #59c9ff, #208df8); box-shadow: 0 12px 26px rgba(28,145,255,.45); cursor: pointer; min-width: 220px; }
+    @media (max-width: 540px) { .stats { grid-template-columns: 1fr; } .panel { padding: 18px; } }
   </style>
 </head>
 <body>
 <canvas id="game"></canvas>
 <div class="vignette"></div>
 <div class="hud">
-  <div class="left">
-    <div id="score" class="pill">Score: 0</div>
-    <div id="combo" class="pill">Combo x1</div>
-  </div>
-  <div class="right">
-    <div id="timer" class="pill">02:00</div>
-  </div>
+  <div class="left"><div id="score" class="pill">Score: 0</div><div id="combo" class="pill">Combo x1</div></div>
+  <div class="right"><div id="timer" class="pill">02:00</div></div>
 </div>
-<button id="capture" class="capture" aria-label="Capture"></button>
-<div id="overlay" class="overlay">
-  <div class="panel" id="panel"></div>
-</div>
+<div class="controls-help">Gauche: déplacer · Droite: viser · Centre: capturer</div>
+<button id="capture" class="capture" aria-label="Capturer"></button>
+<div id="overlay" class="overlay"><div class="panel" id="panel"></div></div>
 <script>
 const c = document.getElementById('game'), ctx = c.getContext('2d');
 const scoreEl = document.getElementById('score'), timerEl = document.getElementById('timer'), comboEl = document.getElementById('combo');
 const overlay = document.getElementById('overlay'), panel = document.getElementById('panel'), captureBtn = document.getElementById('capture');
-let w,h, score=0, timeLeft=120, running=false, flash=0, combo=1, comboT=0;
-const player = {x:0,y:2.2,z:0, yaw:0, pitch:0};
-const move={x:0,y:0}, look={x:0,y:0};
-const invaders=[];
-function resize(){w=c.width=innerWidth*devicePixelRatio; h=c.height=innerHeight*devicePixelRatio; ctx.setTransform(devicePixelRatio,0,0,devicePixelRatio,0,0);} resize(); addEventListener('resize',resize);
+let w, h, score = 0, timeLeft = 120, running = false, flash = 0, combo = 1, comboT = 0, bestCombo = 1;
+const player = { x: 0, y: 2.2, z: 0, yaw: 0, pitch: 0 };
+const move = { x: 0, y: 0 }, look = { x: 0, y: 0 };
+let stars = [];
+const invaders = [];
+function resize() { w = c.width = innerWidth * devicePixelRatio; h = c.height = innerHeight * devicePixelRatio; ctx.setTransform(devicePixelRatio,0,0,devicePixelRatio,0,0); stars = Array.from({length: Math.min(180, Math.floor(innerWidth*0.35))}, (_,i)=>({x:(i*97)%innerWidth, y:(i*61)%Math.max(100,innerHeight*0.55), a:0.2+((i%7)/10)})); }
+resize(); addEventListener('resize', resize);
 function seeded(i){ return (Math.sin(i*999.13)*43758.5453)%1; }
 function makeInvader(seed, size){ const arr=[]; for(let y=0;y<size;y++){ arr[y]=[]; for(let x=0;x<Math.ceil(size/2);x++){ const on=seeded(seed+x*17+y*29)>0.45; arr[y][x]=on; arr[y][size-1-x]=on; } } return arr; }
 const sizes=[8,10,12,14,18], pts={8:10,10:20,12:35,14:55,18:110};
-for(let i=0;i<95;i++){
-  const street=Math.floor(i/12), side=i%2? -1:1, z=(i%12)*22-125 + street*2;
-  const size=sizes[Math.floor(Math.random()*sizes.length)], pattern=makeInvader(i+3,size);
-  invaders.push({x:side*10.2, y:1.4+Math.random()*4.6, z, size, pattern, value:pts[size], taken:false, glow:`hsl(${Math.random()*360},90%,62%)`});
-}
+for(let i=0;i<120;i++){ const street=Math.floor(i/14), side=i%2? -1:1, z=(i%14)*20-145 + street*2; const size=sizes[Math.floor(Math.random()*sizes.length)], pattern=makeInvader(i+3,size); invaders.push({x:side*(9+Math.random()*3), y:1.2+Math.random()*5.2, z, size, pattern, value:pts[size], taken:false, glow:`hsl(${Math.random()*360},88%,62%)`}); }
 function toCam(p){ const dx=p.x-player.x, dy=p.y-player.y, dz=p.z-player.z; const cy=Math.cos(-player.yaw), sy=Math.sin(-player.yaw); const x=dx*cy-dz*sy, z=dx*sy+dz*cy; const cp=Math.cos(-player.pitch), sp=Math.sin(-player.pitch); const y=dy*cp-z*sp; const z2=dy*sp+z*cp; return {x,y,z:z2}; }
-function project(v){ if(v.z<0.2) return null; const f=760; return {x:w/devicePixelRatio/2 + v.x*f/v.z, y:h/devicePixelRatio/2 - v.y*f/v.z, s:f/v.z}; }
-function drawCity(){
-  const vh=h/devicePixelRatio, vw=w/devicePixelRatio;
-  const sky=ctx.createLinearGradient(0,0,0,vh); sky.addColorStop(0,'#10284a'); sky.addColorStop(0.45,'#163965'); sky.addColorStop(1,'#101723');
-  ctx.fillStyle=sky; ctx.fillRect(0,0,vw,vh);
-  for(let i=0;i<80;i++){ const x=(i*157)%vw; const y=(i*83)%Math.max(90,vh*0.45); ctx.fillStyle=`rgba(255,255,255,${0.03 + (i%4)*0.02})`; ctx.fillRect(x,y,2,2); }
-  ctx.fillStyle='#2e2b32'; ctx.fillRect(0,vh*0.66,vw,vh*0.34);
-  for(let n=-13;n<24;n++){
-    const z=n*15;
-    for(const side of [-1,1]){
-      const base=toCam({x:side*12,y:0,z}), top=toCam({x:side*12,y:12,z}), base2=toCam({x:side*12,y:0,z+13}), top2=toCam({x:side*12,y:12,z+13});
-      const p1=project(base), p2=project(top), p3=project(top2), p4=project(base2); if(!p1||!p2||!p3||!p4) continue;
-      const grad=ctx.createLinearGradient(p1.x,p1.y,p2.x,p2.y); grad.addColorStop(0,side<0?'#ccbda5':'#b8a891'); grad.addColorStop(1,side<0?'#8f806a':'#86765f');
-      ctx.fillStyle=grad; ctx.beginPath(); ctx.moveTo(p1.x,p1.y); ctx.lineTo(p2.x,p2.y); ctx.lineTo(p3.x,p3.y); ctx.lineTo(p4.x,p4.y); ctx.closePath(); ctx.fill();
-    }
-  }
-}
-function drawInvader(inv){ if(inv.taken) return; const cam=toCam(inv), p=project(cam); if(!p) return; const tile=Math.max(2,p.s*0.1), size=inv.size*tile, ox=p.x-size/2, oy=p.y-size/2;
-  ctx.fillStyle='rgba(16,20,30,.96)'; ctx.fillRect(ox-5,oy-5,size+10,size+10);
-  ctx.shadowColor=inv.glow; ctx.shadowBlur=Math.min(25, p.s*0.7); ctx.fillStyle=inv.glow;
-  for(let y=0;y<inv.size;y++) for(let x=0;x<inv.size;x++) if(inv.pattern[y][x]) ctx.fillRect(ox+x*tile,oy+y*tile,tile-0.2,tile-0.2);
-  ctx.shadowBlur=0;
-  inv._screen={x:ox,y:oy,w:size,h:size,centerX:p.x,centerY:p.y,depth:cam.z};
-}
-function update(dt){
-  player.yaw += look.x*dt*0.0016;
-  player.pitch = Math.max(-0.8,Math.min(0.8,player.pitch + look.y*dt*0.0016));
-  const sp=dt*0.0105;
-  player.x += (Math.cos(player.yaw)*move.x + Math.sin(player.yaw)*move.y)*sp;
-  player.z += (-Math.sin(player.yaw)*move.x + Math.cos(player.yaw)*move.y)*sp;
-  player.x = Math.max(-5.5,Math.min(5.5,player.x));
-  player.z = Math.max(-142,Math.min(146,player.z));
-  comboT=Math.max(0, comboT-dt/1000);
-  if(comboT===0) combo=1;
-}
-function attemptCapture(){
-  if(!running) return;
-  let best=null;
-  const cx=w/devicePixelRatio/2, cy=h/devicePixelRatio/2;
-  for(const inv of invaders){
-    if(inv.taken||!inv._screen) continue;
-    const d=Math.hypot(inv._screen.centerX-cx, inv._screen.centerY-cy);
-    if(d<74 && inv._screen.depth<40 && (!best||d<best.d)) best={inv,d};
-  }
-  if(best){
-    best.inv.taken=true;
-    score += Math.round(best.inv.value * combo);
-    combo = Math.min(5, combo + 0.4);
-    comboT = 3;
-    scoreEl.textContent=`Score: ${score}`;
-    comboEl.textContent=`Combo x${combo.toFixed(1)}`;
-    flash=190;
-  }
-}
+function project(v){ if(v.z<0.2) return null; const f=780; return {x:w/devicePixelRatio/2 + v.x*f/v.z, y:h/devicePixelRatio/2 - v.y*f/v.z, s:f/v.z}; }
+function drawCity(){ const vh=h/devicePixelRatio, vw=w/devicePixelRatio; const sky=ctx.createLinearGradient(0,0,0,vh); sky.addColorStop(0,'#102b51'); sky.addColorStop(0.5,'#163a64'); sky.addColorStop(1,'#0f1622'); ctx.fillStyle=sky; ctx.fillRect(0,0,vw,vh); for(const s of stars){ ctx.fillStyle=`rgba(255,255,255,${s.a})`; ctx.fillRect(s.x,s.y,2,2);} ctx.fillStyle='#23252f'; ctx.fillRect(0,vh*0.66,vw,vh*0.34); for(let n=-14;n<26;n++){ const z=n*14; for(const side of [-1,1]){ const base=toCam({x:side*12,y:0,z}), top=toCam({x:side*12,y:12,z}), base2=toCam({x:side*12,y:0,z+13}), top2=toCam({x:side*12,y:12,z+13}); const p1=project(base), p2=project(top), p3=project(top2), p4=project(base2); if(!p1||!p2||!p3||!p4) continue; const grad=ctx.createLinearGradient(p1.x,p1.y,p2.x,p2.y); grad.addColorStop(0,side<0?'#dac9ad':'#d4c4ab'); grad.addColorStop(1,side<0?'#8d7d66':'#81735e'); ctx.fillStyle=grad; ctx.beginPath(); ctx.moveTo(p1.x,p1.y); ctx.lineTo(p2.x,p2.y); ctx.lineTo(p3.x,p3.y); ctx.lineTo(p4.x,p4.y); ctx.closePath(); ctx.fill(); } } }
+function drawInvader(inv){ if(inv.taken) return; const cam=toCam(inv), p=project(cam); if(!p) return; const tile=Math.max(2,p.s*0.1), size=inv.size*tile, ox=p.x-size/2, oy=p.y-size/2; ctx.fillStyle='rgba(8,13,24,.96)'; ctx.fillRect(ox-6,oy-6,size+12,size+12); ctx.shadowColor=inv.glow; ctx.shadowBlur=Math.min(38,p.s*0.7); ctx.fillStyle=inv.glow; for(let y=0;y<inv.size;y++) for(let x=0;x<inv.size;x++) if(inv.pattern[y][x]) ctx.fillRect(ox+x*tile,oy+y*tile,tile-0.2,tile-0.2); ctx.shadowBlur=0; inv._screen={centerX:p.x,centerY:p.y,depth:cam.z}; }
+function update(dt){ player.yaw += look.x*dt*0.0016; player.pitch = Math.max(-0.82,Math.min(0.82,player.pitch + look.y*dt*0.0016)); const sp=dt*0.0105; player.x += (Math.cos(player.yaw)*move.x + Math.sin(player.yaw)*move.y)*sp; player.z += (-Math.sin(player.yaw)*move.x + Math.cos(player.yaw)*move.y)*sp; player.x = Math.max(-5.8,Math.min(5.8,player.x)); player.z = Math.max(-148,Math.min(156,player.z)); comboT=Math.max(0, comboT-dt/1000); if(comboT===0) combo=1; }
+function attemptCapture(){ if(!running) return; let best=null; const cx=w/devicePixelRatio/2, cy=h/devicePixelRatio/2; for(const inv of invaders){ if(inv.taken||!inv._screen) continue; const d=Math.hypot(inv._screen.centerX-cx, inv._screen.centerY-cy); if(d<78 && inv._screen.depth<42 && (!best||d<best.d)) best={inv,d}; } if(best){ best.inv.taken=true; score += Math.round(best.inv.value * combo); combo = Math.min(8, combo + 0.5); bestCombo = Math.max(bestCombo, combo); comboT = 3.5; scoreEl.textContent=`Score: ${score}`; comboEl.textContent=`Combo x${combo.toFixed(1)}`; flash=190; } }
 let prev=performance.now();
-function loop(t){
-  const dt=t-prev; prev=t;
-  if(running){
-    timeLeft=Math.max(0,timeLeft-dt/1000);
-    if(timeLeft===0){ endGame(); }
-    const m=Math.floor(timeLeft/60), s=Math.floor(timeLeft%60);
-    timerEl.textContent=`${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`;
-    update(dt);
-  }
-  drawCity();
-  invaders.sort((a,b)=>(b._screen?.depth||0)-(a._screen?.depth||0)); invaders.forEach(drawInvader);
-  const cx=w/devicePixelRatio/2, cy=h/devicePixelRatio/2;
-  ctx.strokeStyle='rgba(255,255,255,.95)'; ctx.lineWidth=2.2;
-  ctx.beginPath(); ctx.moveTo(cx-15,cy); ctx.lineTo(cx+15,cy); ctx.moveTo(cx,cy-15); ctx.lineTo(cx,cy+15); ctx.stroke();
-  if(flash>0){ctx.fillStyle=`rgba(255,255,255,${flash/220})`; ctx.fillRect(0,0,w,h); flash-=dt;}
-  requestAnimationFrame(loop);
-}
+function loop(t){ const dt=t-prev; prev=t; if(running){ timeLeft=Math.max(0,timeLeft-dt/1000); if(timeLeft===0){ endGame(); } const m=Math.floor(timeLeft/60), s=Math.floor(timeLeft%60); timerEl.textContent=`${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`; update(dt);} drawCity(); invaders.sort((a,b)=>(b._screen?.depth||0)-(a._screen?.depth||0)); invaders.forEach(drawInvader); const cx=w/devicePixelRatio/2, cy=h/devicePixelRatio/2; ctx.strokeStyle='rgba(255,255,255,.98)'; ctx.lineWidth=2.2; ctx.beginPath(); ctx.arc(cx,cy,18,0,Math.PI*2); ctx.moveTo(cx-26,cy); ctx.lineTo(cx+26,cy); ctx.moveTo(cx,cy-26); ctx.lineTo(cx,cy+26); ctx.stroke(); if(flash>0){ctx.fillStyle=`rgba(255,255,255,${flash/220})`; ctx.fillRect(0,0,w,h); flash-=dt;} requestAnimationFrame(loop); }
 requestAnimationFrame(loop);
-function renderIntro(){
-  panel.innerHTML = `<h1>Invader Hunt: Paris</h1>
-    <div class="subtitle">Neon Ops Edition</div>
-    <p>Photographie les mosaïques les plus rares en 2 minutes. Vise au centre, déclenche rapidement pour monter ton combo.</p>
-    <div class="stats">
-      <div class="stat">Règle #1<b>Reste mobile</b></div>
-      <div class="stat">Règle #2<b>Vise précis</b></div>
-      <div class="stat">Règle #3<b>Maintiens combo</b></div>
-    </div>
-    <button id="start">Start Mission</button>`;
-  document.getElementById('start').onclick=start;
-}
-function endGame(){
-  running=false;
-  overlay.style.display='flex';
-  panel.innerHTML = `<h2>Mission terminée</h2><p>Score final: <b>${score}</b></p><p>Combo max: <b>x${combo.toFixed(1)}</b></p><button id='restart'>Rejouer</button>`;
-  document.getElementById('restart').onclick=start;
-}
-function start(){
-  score=0; timeLeft=120; running=true; combo=1; comboT=0;
-  overlay.style.display='none';
-  invaders.forEach(v=>v.taken=false);
-  player.x=0; player.y=2.2; player.z=0; player.yaw=0; player.pitch=0;
-  scoreEl.textContent='Score: 0'; comboEl.textContent='Combo x1';
-}
+function renderIntro(){ panel.innerHTML = `<h1>Invader Hunt</h1><div class='subtitle'>Neon Safari • Édition concours</div><p>Chasse les mosaïques extraterrestres dans les ruelles néon. Plus tu captures vite et précis, plus ton combo explose.</p><div class='stats'><div class='stat'>Précision<b>Réticule central</b></div><div class='stat'>Vitesse<b>Combo 3.5 sec</b></div><div class='stat'>Contrôle<b>2 zones tactiles</b></div></div><button class='primary' id='start'>Lancer la mission</button>`; document.getElementById('start').addEventListener('click', start, {once:false}); }
+function endGame(){ running=false; overlay.style.display='flex'; panel.innerHTML = `<h2>Mission terminée</h2><p>Score final: <b>${score}</b></p><p>Combo max: <b>x${bestCombo.toFixed(1)}</b></p><button class='primary' id='restart'>Rejouer</button>`; document.getElementById('restart').addEventListener('click', start); }
+function start(){ score=0; timeLeft=120; running=true; combo=1; comboT=0; bestCombo=1; overlay.style.display='none'; invaders.forEach(v=>v.taken=false); player.x=0; player.y=2.2; player.z=0; player.yaw=0; player.pitch=0; scoreEl.textContent='Score: 0'; comboEl.textContent='Combo x1'; }
 renderIntro();
-captureBtn.onclick=attemptCapture;
-
-function bindTouch(e){
-  if (e.target.closest('button') || e.target.closest('.overlay')) return;
-  const t=[...e.touches];
-  if(t[0]){
-    if(t[0].clientX<innerWidth*0.45){move.x=(t[0].clientY-innerHeight*0.8)/30; move.y=(t[0].clientX-innerWidth*0.2)/30;}
-    else {look.x=(t[0].clientX-innerWidth*0.8)/26; look.y=(t[0].clientY-innerHeight*0.4)/26;}
-  }
-  if(t[1]){
-    const a=t[0],b=t[1]; const L=a.clientX<b.clientX?a:b, R=a.clientX<b.clientX?b:a;
-    move.x=(L.clientY-innerHeight*0.8)/30; move.y=(L.clientX-innerWidth*0.2)/30;
-    look.x=(R.clientX-innerWidth*0.8)/26; look.y=(R.clientY-innerHeight*0.4)/26;
-  }
-  if(!t.length){move.x=move.y=look.x=look.y=0;}
-  e.preventDefault();
-}
-addEventListener('touchstart',bindTouch,{passive:false});
-addEventListener('touchmove',bindTouch,{passive:false});
-addEventListener('touchend',bindTouch,{passive:false});
-let mouseDown=false;
-addEventListener('mousedown',e=>{ if(e.target.closest('button')) return; mouseDown=true; });
-addEventListener('mouseup',()=>{mouseDown=false;move.x=move.y=look.x=look.y=0;});
-addEventListener('mousemove',e=>{ if(!mouseDown) return; look.x=e.movementX*0.6; look.y=e.movementY*0.6; move.x=-1; });
+captureBtn.addEventListener('pointerdown', e=>{ e.preventDefault(); attemptCapture(); });
+function bindTouch(e){ if (e.target.closest('.overlay') || e.target.closest('#capture')) return; const t=[...e.touches]; if(t[0]){ if(t[0].clientX<innerWidth*0.5){ move.x=(t[0].clientY-innerHeight*0.78)/28; move.y=(t[0].clientX-innerWidth*0.2)/36; } else { look.x=(t[0].clientX-innerWidth*0.8)/24; look.y=(t[0].clientY-innerHeight*0.4)/24; } } if(t[1]){ const a=t[0],b=t[1]; const L=a.clientX<b.clientX?a:b, R=a.clientX<b.clientX?b:a; move.x=(L.clientY-innerHeight*0.78)/28; move.y=(L.clientX-innerWidth*0.2)/36; look.x=(R.clientX-innerWidth*0.8)/24; look.y=(R.clientY-innerHeight*0.4)/24; } if(!t.length){ move.x=move.y=look.x=look.y=0; } e.preventDefault(); }
+addEventListener('touchstart',bindTouch,{passive:false}); addEventListener('touchmove',bindTouch,{passive:false}); addEventListener('touchend',bindTouch,{passive:false});
+let mouseDown=false; addEventListener('mousedown',e=>{ if(e.target.closest('button')||e.target.closest('.overlay')) return; mouseDown=true; }); addEventListener('mouseup',()=>{mouseDown=false;move.x=move.y=look.x=look.y=0;}); addEventListener('mousemove',e=>{ if(!mouseDown) return; look.x=e.movementX*0.62; look.y=e.movementY*0.62; move.x=-1; });
 </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Corriger un problème où le bouton de démarrage/capture n’était pas fiable sur mobile (notamment iPhone) et améliorer la fiabilité des entrées tactiles. 
- Moderniser l’interface et la charte visuelle pour une présentation néon haut contraste et adaptée aux safe areas iOS. 
- Améliorer la jouabilité et le ressenti (visée, combo, distribution des cibles, feedback visuel) pour une expérience plus dynamique. 
- Localiser l’accueil en français et clarifier l’onboarding pour une présentation de concours.

### Description
- Refonte complète de `index.html`: langue `fr`, nouveau titre, palette de couleurs, glassmorphism panel, typographie, et composants HUD (`.pill`, `.panel`, `.capture`, `.controls-help`).
- Fiabilisation des interactions tactiles: `capture` utilise `pointerdown`, le handler tactile ignore l’overlay et le bouton capture pour éviter d’intercepter les taps, et le bouton de démarrage est lié via `addEventListener('click', ...)` pour meilleure compatibilité mobile. 
- Mises à jour du moteur de jeu: ajout d’un tableau d’étoiles, augmentation/distribution des invaders, ajustements du `project`/`toCam` rendu, reticule central redesign, tuning des paramètres de mouvement/visée et du système de combo (durée/cap et suivi `bestCombo`).
- Améliorations responsive et safe-area iOS: padding dynamique par `env(safe-area-inset-*)`, tailles adaptatives (`clamp`), et petites corrections sur écouteurs d’événements (`touchstart/move/end`, `mousedown/mousemove`) pour ne pas bloquer les contrôles UI.

### Testing
- Aucun test automatisé (CI/unit) n’est présent ni n’a été exécuté pour cette modification; changements à valider via tests fonctionnels en navigateur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f70d7460988322957b83c0b362d84f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewrites input event handling (touch/pointer/mouse) and retunes core gameplay parameters (capture thresholds, combo rules, target placement), which could regress controls or scoring on some devices.
> 
> **Overview**
> Rethemes and localizes the single-page game to **Neon Safari** (French `lang`, new title/copy), with a refreshed HUD/overlay styling, safe-area-aware layout, responsive typography, and a new on-screen controls hint.
> 
> Improves mobile interaction reliability by switching capture to `pointerdown`, adjusting touch binding to ignore the overlay/capture button, and using `addEventListener` for start/restart clicks. Gameplay/render tuning includes a starfield background, redesigned reticle, more/repositioned invaders, updated projection/movement bounds, and revised combo behavior with `bestCombo` tracking shown on the end screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13fbffd6c9461e876fd5ebb20eb88fbaa5f3b3ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->