### PR TITLE
Améliore contrôles tactiles et restaure visibilité du terrain

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,13 @@ let w = 0, h = 0, score = 0, timeLeft = 120, running = false, flash = 0;
 let combo = 1, comboTimer = 0, bestCombo = 1;
 const player = { x: 0, y: 2, z: 0, yaw: 0, pitch: 0 };
 const move = { x: 0, y: 0 }, look = { x: 0, y: 0 };
+const controlTuning = {
+  moveRadius: 78,
+  lookRadius: 96,
+  moveDeadzone: 0.08,
+  lookDeadzone: 0.06,
+  lookSpeed: 9.5
+};
 
 let stars = [];
 const invaders = [];
@@ -262,8 +269,22 @@ function drawBackground() {
     ctx.fillRect(s.x, s.y, 2, 2);
   }
 
-  ctx.fillStyle = '#1f212b';
-  ctx.fillRect(0, h * 0.65, w, h * 0.35);
+  const horizon = h * 0.66;
+  const ground = ctx.createLinearGradient(0, horizon, 0, h);
+  ground.addColorStop(0, '#24314a');
+  ground.addColorStop(1, '#090d16');
+  ctx.fillStyle = ground;
+  ctx.fillRect(0, horizon, w, h - horizon);
+
+  ctx.strokeStyle = 'rgba(120, 188, 255, 0.2)';
+  ctx.lineWidth = 1;
+  for (let i = 0; i < 7; i++) {
+    const y = horizon + ((i + 1) / 7) * (h - horizon);
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(w, y);
+    ctx.stroke();
+  }
 }
 
 function drawInvader(inv, t) {
@@ -305,10 +326,10 @@ function drawReticle() {
 }
 
 function update(dt) {
-  player.yaw += look.x * dt * 0.00135;
-  player.pitch = Math.max(-0.78, Math.min(0.78, player.pitch + look.y * dt * 0.00135));
+  player.yaw += look.x * dt * 0.00078;
+  player.pitch = Math.max(-0.72, Math.min(0.72, player.pitch + look.y * dt * 0.00078));
 
-  const sp = dt * 0.01;
+  const sp = dt * 0.0072;
   player.x += (Math.cos(player.yaw) * move.x + Math.sin(player.yaw) * move.y) * sp;
   player.z += (-Math.sin(player.yaw) * move.x + Math.cos(player.yaw) * move.y) * sp;
 
@@ -421,17 +442,27 @@ function loop(now) {
 const touches = new Map();
 function resetControls() { move.x = move.y = look.x = look.y = 0; }
 function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
+function shapedStick(dx, dy, radius, deadzone) {
+  const dist = Math.hypot(dx, dy);
+  if (dist < radius * deadzone) return { x: 0, y: 0 };
+  const capped = Math.min(radius, dist);
+  const strength = capped / radius;
+  return { x: (dx / (dist || 1)) * strength, y: (dy / (dist || 1)) * strength };
+}
+
 function updateTouchControls() {
   resetControls();
   for (const t of touches.values()) {
     const dx = t.x - t.startX;
     const dy = t.y - t.startY;
     if (t.side === 'left') {
-      move.x += clamp(dy / 34, -1.6, 1.6);
-      move.y += clamp(dx / 34, -1.6, 1.6);
+      const stick = shapedStick(dx, dy, controlTuning.moveRadius, controlTuning.moveDeadzone);
+      move.x += clamp(stick.y, -1, 1);
+      move.y += clamp(stick.x, -1, 1);
     } else {
-      look.x += clamp(dx / 6.5, -18, 18);
-      look.y += clamp(dy / 6.5, -18, 18);
+      const stick = shapedStick(dx, dy, controlTuning.lookRadius, controlTuning.lookDeadzone);
+      look.x += clamp(stick.x * controlTuning.lookSpeed, -9, 9);
+      look.y += clamp(stick.y * controlTuning.lookSpeed, -9, 9);
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Corriger des mouvements de caméra trop brutaux qui faisaient disparaitre les invaders au premier toucher. 
- Rendre la sensibilité du joystick tactile utilisable, car elle était beaucoup trop élevée pour viser et se déplacer correctement. 
- Rendre le sol/terrain visible pour éviter l’effet « invaders dans le vide » qui désoriente le joueur.

### Description
- Ajout de constantes de réglage `controlTuning` pour centraliser `moveRadius`, `lookRadius`, `moveDeadzone`, `lookDeadzone` et `lookSpeed`.
- Ajout d’une fonction `shapedStick(dx, dy, radius, deadzone)` et remplacement des deltas bruts par un joystick virtuel avec deadzone et rayon plafonné dans `updateTouchControls`.
- Réduction des multiplicateurs de rotation (`yaw`/`pitch`) et de la vitesse de déplacement (`sp`) pour limiter les sauts de vue et stabiliser le gameplay.
- Refonte du rendu du sol avec un dégradé d’horizon et des lignes guides pour que le terrain soit clairement visible sous les invaders.

### Testing
- Inspection automatique du fichier modifié via commandes d’affichage (`sed -n` et `nl`) pour vérifier que les changements sont présents et bien formés, réussite.
- Revue automatisée du diff pour confirmer que les modifications de contrôle et de rendu ont été appliquées sans erreurs de syntaxe, réussite.
- Aucun test unitaire automatisé dans le dépôt; validations réalisées par inspection statique des modifications et vérification que le code est syntaxiquement cohérent, réussite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f71287e5c0832297b0d4645eaf3fe7)